### PR TITLE
changing urljoin to os.path.join

### DIFF
--- a/get_updated_files.py
+++ b/get_updated_files.py
@@ -3,7 +3,7 @@
 import argparse
 import datetime
 import sys
-from urllib.parse import urljoin
+from os.path import join
 
 __VERSION__ = "2.0.0"
 
@@ -43,7 +43,7 @@ def main():
             # which might not be exactly in sync with each other
             if (changed_at - updated_since).total_seconds() > args.min_delta:
                 if args.url_base:
-                    print(urljoin(args.url_base, path))
+                    print(join(args.url_base, path))
                 else:
                     print(path)
 


### PR DESCRIPTION
The behavior of urljoin is on my opionion not constructive, because of its description "Construct a full (“absolute”) URL by combining a “base URL” (base) with another URL (url). Informally, this uses components of the base URL, in particular the addressing scheme, the network location and (part of) the path, to provide missing components in the relative URL." (https://docs.python.org/3/library/urllib.parse.html#urllib.parse.urljoin)